### PR TITLE
PI-1815: move to new S3 based Maven repo and TAR v2.1.2

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -3,7 +3,7 @@
 
 # TruexAdRenderer Android/Fire TV Documentation
 
-Version 1.0.0
+Version 2.1.0
 
 ## Contents
 
@@ -145,24 +145,24 @@ The easiest way to add `TruexAdRenderer` is via Maven. The renderer will be main
 
 1. Add the Maven repository to your project:
     ```
-    https://raw.github.com/socialvibe/truex-tv-integrations/android
+    https://ctv.truex.com/android/maven
     ```
 1. Add the dependency:
     * group ID: `com.truex`
     * artifact ID: `TruexAdRenderer-tv`
-    * version: `2.0.0`
+    * version: `2.1.2`
 
 #### Gradle Example
 
 ```groovy
 repositories {
     maven {
-        url "https://raw.github.com/socialvibe/truex-tv-integrations/android"
+        url "https://ctv.truex.com/android/maven"
     }
 }
 
 dependencies {
-    implementation 'com.truex:TruexAdRenderer-tv:2.0.0'
+    implementation 'com.truex:TruexAdRenderer-tv:2.1.2'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,69 @@
 Documentation and reference apps for true[X]'s Android/Fire TV-based integration library.
 
 The current version of the integration documentation can be found here: [TruexAdRenderer-AndroidTV Documentation](DOCS.md).
+
+## Getting Started
+
+The first step is to fetch the latest version of the TruexAdRenderer. The easiest way to add the TruexAdRenderer is via Maven. true[X] manages its Maven repository on Amazon S3.
+
+### Adding the Renderer
+
+In your app's `build.gradle`:
+
+1. Under `repositories`, add a new maven entry with the url: <https://ctv.truex.com/android/maven>
+2. Under `dependencies`, add `compile 'com.truex:TruexAdRenderer-tv:2.1.2'`
+
+#### Example app's build.gradle
+
+```
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 30
+    defaultConfig {
+        applicationId "com.example.demoapp"
+        minSdkVersion 17
+        targetSdkVersion 30
+        versionCode 1
+        versionName "1.0"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+repositories {
+    maven {
+        url "https://ctv.truex.com/android/maven"
+    }
+}
+
+dependencies {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.truex:TruexAdRenderer-tv:2.1.2'
+}
+```
+
+* * *
+
+## Next Steps
+
+### Integration Example
+
+Here is [an example][sheppard] of a minimal android application that uses the TruexAdRenderer.
+
+### Google Ad Manager (GAM) DAI SDK Integration Example
+
+Here is a [reference application](https://github.com/socialvibe/truex-android-google-ad-manager-reference-app) that outlines how to use the Google Ad Manager (GAM) DAI SDK with the TruexAdRenderer.
+
+### Integration Documentation
+
+The [TruexAdRenderer documentation][docs] outlines how to use the TruexAdRenderer. Included within the documentation is a description of the public API for the TruexAdRenderer as well as a description of the event flow.
+
+[sheppard]: https://github.com/socialvibe/sheppard
+[gam]: https://github.com/socialvibe/truex-tvos-google-ad-manager-reference-app
+[docs]: https://github.com/socialvibe/truex-androidtv-integrations/blob/develop/DOCS.md


### PR DESCRIPTION
I refreshed the Getting Started and Docs pages with the migration to the Maven repository and TAR v2.1.2.

The Getting Started page will now be in the main Git repo as opposed to its wiki which is more manageable.